### PR TITLE
Fix array index after unset

### DIFF
--- a/hook-dns-transip-api.php
+++ b/hook-dns-transip-api.php
@@ -136,6 +136,7 @@ elseif( $action === "clean_challenge" )
 
     if( $found > 0)
     {
+        $dnsEntries = array_values($dnsEntries);
         try
         {
             // Commit the changes to the TransIP DNS servers


### PR DESCRIPTION
If the _acme-challenge record in the $dnsEntries array isn't the last record in the array. Unset removes an index in the middle of the array and the array is refused by the transip API (having a blank line). Manual cleanup is required in this case.

$dnsEntries = array_values($dnsEntries); will reindex all the keys of the array from 0 and fixes this issue.
