### PR TITLE
Dehydrated-0.7_HookWrapper

### DIFF
--- a/hook-dns-transip-api.php
+++ b/hook-dns-transip-api.php
@@ -108,13 +108,13 @@ if( $action === "deploy_challenge" )
 
         if ($continue < sizeof($dns_servers) )
         {
-            echo "Result not ready, retrying in $sleeptime seconds\n";
+            echo "Result not ready, retrying in $sleeptime seconds, waiting for DNS record to become known.\n";
             sleep($sleeptime);
             $continue++;
         }
     }
-    echo "Sleeping an additional 10 minutes";
-    sleep(600);
+    echo "Sleeping an additional 5 minute, waiting for DNS record to become known.";
+    sleep(300);
 }
 elseif( $action === "clean_challenge" )
 {

--- a/hooks.sh
+++ b/hooks.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+deploy_challenge() {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    # This hook is called once for every domain that needs to be
+    # validated, including any alternative names you may have listed.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The domain name (CN or subject alternative name) being
+    #   validated.
+    # - TOKEN_FILENAME
+    #   The name of the file containing the token to be served for HTTP
+    #   validation. Should be served by your web server as
+    #   /.well-known/acme-challenge/${TOKEN_FILENAME}.
+    # - TOKEN_VALUE
+    #   The token value that needs to be served for validation. For DNS
+    #   validation, this is what you want to put in the _acme-challenge
+    #   TXT record. For HTTP validation it is the value that is expected
+    #   be found in the $TOKEN_FILENAME file.
+
+    # Simple example: Use nsupdate with local named
+    # printf 'server 127.0.0.1\nupdate add _acme-challenge.%s 300 IN TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
+
+    # Wrapping Sigio's dehydreated-transip-dns-validator PHP-script inside new hook system.
+        echo "Starting TransIP hook ${FUNCNAME[0]} :"
+        ${BASEDIR}/dehydrated-transip-dns-validator/./hook-dns-transip-api.php ${FUNCNAME[0]} $DOMAIN $TOKEN_FILENAME $TOKEN_VALUE
+}
+
+clean_challenge() {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    # This hook is called after attempting to validate each domain,
+    # whether or not validation was successful. Here you can delete
+    # files or DNS records that are no longer needed.
+    #
+    # The parameters are the same as for deploy_challenge.
+
+    # Simple example: Use nsupdate with local named
+    # printf 'server 127.0.0.1\nupdate delete _acme-challenge.%s TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
+
+	# Wrapping Sigio's dehydreated-transip-dns-validator PHP-script inside new hook system.
+        echo "Starting TransIP hook ${FUNCNAME[0]} :"
+        ${BASEDIR}/dehydrated-transip-dns-validator/./hook-dns-transip-api.php ${FUNCNAME[0]} $DOMAIN $TOKEN_FILENAME $TOKEN_VALUE
+}
+
+sync_cert() {
+    local KEYFILE="${1}" CERTFILE="${2}" FULLCHAINFILE="${3}" CHAINFILE="${4}" REQUESTFILE="${5}"
+
+    # This hook is called after the certificates have been created but before
+    # they are symlinked. This allows you to sync the files to disk to prevent
+    # creating a symlink to empty files on unexpected system crashes.
+    #
+    # This hook is not intended to be used for further processing of certificate
+    # files, see deploy_cert for that.
+    #
+    # Parameters:
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+    # - REQUESTFILE
+    #   The path of the file containing the certificate signing request.
+
+    # Simple example: sync the files before symlinking them
+    # sync "${KEYFILE}" "${CERTFILE}" "${FULLCHAINFILE}" "${CHAINFILE}" "${REQUESTFILE}"
+}
+
+deploy_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
+
+    # This hook is called once for each certificate that has been
+    # produced. Here you might, for instance, copy your new certificates
+    # to service-specific locations and reload the service.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+    # - TIMESTAMP
+    #   Timestamp when the specified certificate was created.
+
+    # Simple example: Copy file to nginx config
+    # cp "${KEYFILE}" "${FULLCHAINFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
+    # systemctl reload nginx
+
+	# Wrapping Sigio's dehydreated-transip-dns-validator PHP-script inside new hook system.
+#        echo "Starting TransIP hook ${FUNCNAME[0]} :"
+#        ${BASEDIR}/dehydrated-transip-dns-validator/./hook-dns-transip-api.php ${FUNCNAME[0]} $DOMAIN $KEYFILE $CERTFILE $FULLCHAINFILE $CHAINFILE $TIMESTAMP
+}
+
+deploy_ocsp() {
+    local DOMAIN="${1}" OCSPFILE="${2}" TIMESTAMP="${3}"
+
+    # This hook is called once for each updated ocsp stapling file that has
+    # been produced. Here you might, for instance, copy your new ocsp stapling
+    # files to service-specific locations and reload the service.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - OCSPFILE
+    #   The path of the ocsp stapling file
+    # - TIMESTAMP
+    #   Timestamp when the specified ocsp stapling file was created.
+
+    # Simple example: Copy file to nginx config
+    # cp "${OCSPFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
+    # systemctl reload nginx
+}
+
+
+unchanged_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+
+    # This hook is called once for each certificate that is still
+    # valid and therefore wasn't reissued.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+
+	# Wrapping Sigio's dehydreated-transip-dns-validator PHP-script inside new hook system.
+        echo "Starting TransIP hook ${FUNCNAME[0]} :"
+        ${BASEDIR}/dehydrated-transip-dns-validator/./hook-dns-transip-api.php ${FUNCNAME[0]} $DOMAIN $KEYFILE $CERTFILE $FULLCHAINFILE $CHAINFILE
+}
+
+invalid_challenge() {
+    local DOMAIN="${1}" RESPONSE="${2}"
+
+    # This hook is called if the challenge response has failed, so domain
+    # owners can be aware and act accordingly.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - RESPONSE
+    #   The response that the verification server returned
+
+    # Simple example: Send mail to root
+    # printf "Subject: Validation of ${DOMAIN} failed!\n\nOh noez!" | sendmail root
+}
+
+request_failure() {
+    local STATUSCODE="${1}" REASON="${2}" REQTYPE="${3}" HEADERS="${4}"
+
+    # This hook is called when an HTTP request fails (e.g., when the ACME
+    # server is busy, returns an error, etc). It will be called upon any
+    # response code that does not start with '2'. Useful to alert admins
+    # about problems with requests.
+    #
+    # Parameters:
+    # - STATUSCODE
+    #   The HTML status code that originated the error.
+    # - REASON
+    #   The specified reason for the error.
+    # - REQTYPE
+    #   The kind of request that was made (GET, POST...)
+    # - HEADERS
+    #   HTTP headers returned by the CA
+
+    # Simple example: Send mail to root
+    # printf "Subject: HTTP request failed failed!\n\nA http request failed with status ${STATUSCODE}!" | sendmail root
+}
+
+generate_csr() {
+    local DOMAIN="${1}" CERTDIR="${2}" ALTNAMES="${3}"
+
+    # This hook is called before any certificate signing operation takes place.
+    # It can be used to generate or fetch a certificate signing request with external
+    # tools.
+    # The output should be just the certificate signing request formatted as PEM.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain as specified in domains.txt. This does not need to
+    #   match with the domains in the CSR, it's basically just the directory name.
+    # - CERTDIR
+    #   Certificate output directory for this particular certificate. Can be used
+    #   for storing additional files.
+    # - ALTNAMES
+    #   All domain names for the current certificate as specified in domains.txt.
+    #   Again, this doesn't need to match with the CSR, it's just there for convenience.
+
+    # Simple example: Look for pre-generated CSRs
+    # if [ -e "${CERTDIR}/pre-generated.csr" ]; then
+    #   cat "${CERTDIR}/pre-generated.csr"
+    # fi
+}
+
+startup_hook() {
+  # This hook is called before the cron command to do some initial tasks
+  # (e.g. starting a webserver).
+
+  :
+}
+
+exit_hook() {
+  local ERROR="${1:-}"
+
+  # This hook is called at the end of the cron command and can be used to
+  # do some final (cleanup or other) tasks.
+  #
+  # Parameters:
+  # - ERROR
+  #   Contains error message if dehydrated exits with error
+}
+
+HANDLER="$1"; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|sync_cert|deploy_cert|deploy_ocsp|unchanged_cert|invalid_challenge|request_failure|generate_csr|startup_hook|exit_hook)$ ]]; then
+  "$HANDLER" "$@"
+fi


### PR DESCRIPTION
Dehydrated has a new way of using hooks. Using their example hook file I wrapped the existing project inside so you can still use it without a lot of changing.

I needed to update dehydrated as LetsEncrypt moved to an new environment and dehydrated v0.3 did not seem to support this.
The change from LetsEncrypt :
ACME v2 (RFC 8555)

    [Production] https://acme-v02.api.letsencrypt.org/directory
    [Staging] https://acme-staging-v02.api.letsencrypt.org/directory

ACME v1 (Deprecated)

    [Production] https://acme-v01.api.letsencrypt.org/directory
    [Staging] https://acme-staging.api.letsencrypt.org/directory